### PR TITLE
fix: divide fait la bonne operation division réelle plutôt que division entière

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -61,4 +61,4 @@ def divide(a,b):
     ----------
     ZeroDivisionError : Si b est égal à 0.
     """
-    return a // b
+    return a / b


### PR DESCRIPTION
Correction du bug de la fonction divide de operators.py tel que décrit dans l'issue #3.